### PR TITLE
Handle get cookies with oauth (ex: Google)

### DIFF
--- a/src/auth.server.ts
+++ b/src/auth.server.ts
@@ -22,23 +22,25 @@ class AuthManager {
    * @returns {AuthTokens | null} AuthTokens if found and correctly parsed, null otherwise.
    */
   private getAuthTokensFromCookies(): AuthTokens | null {
-    const cookieNameRegex = /^sb-[a-z]+-auth-token$/;
-    const authCookie = cookies()
+    const cookieNameRegex = /^sb-[a-z]+-auth-token.*$/
+    const authCookies = cookies()
       .getAll()
-      .find((cookie) => cookieNameRegex.test(cookie.name));
-
-    if (!authCookie) {
-      return null;
+      .filter((cookie) => cookieNameRegex.test(cookie.name))
+      .sort((a, b) => a.name.localeCompare(b.name))
+    if (!authCookies) {
+      return null
     }
 
+    const authCookieValue = authCookies.map((cookie) => cookie.value).join("")
+
     try {
-      const session = JSON.parse(decodeURIComponent(authCookie.value));
+      const session = JSON.parse(decodeURIComponent(authCookieValue))
       return {
         access_token: session.access_token,
         refresh_token: session.refresh_token,
-      };
+      }
     } catch (error) {
-      return null;
+      return null
     }
   }
 


### PR DESCRIPTION
Hi, your lib is very useful!

I tried to implement it but look like it doesn't work with cookies using oauth.
As the session cookie is too big for cookies, supabase slipt the value into 2 cookies:
![image](https://github.com/Zanzofily/supabase-safesession/assets/10871675/45f427d9-dab7-4436-9860-5f2791ad4d06)
`sb-etbfmqkktewuqbpktqvf-auth-token.0` and  `sb-etbfmqkktewuqbpktqvf-auth-token.1`

I updated the `getAuthTokensFromCookies()` method to handle those those type of cookies.

---

Moreover, I needed to change `subaseServerClient` and `supabaseServerAuth` into functions as I am facing this error:
```
Error: `cookies` was called outside a request scope. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context
``` 

Fix:
```ts
// Export the initialized Supabase client and AuthManager
export const supabaseServerClient = () => createSupabaseServerClient()
export const supabaseServerAuth = () => new AuthManager(supabaseServerClient(), process.env.SUPABASE_JWT_SECRET!)
```

Regards,
---